### PR TITLE
-d doesn't work at the end of the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ Ultimate job/build runner -OR- bash execution as a service.
 
 ```console
 # start the server
-$ hulk server -d
+$ hulk -d server 
+
+# start the server with a specific socket
+$ hulk -d -a /hulk.sock server 
 
 # list jobs
 $ hulk ls


### PR DESCRIPTION
the readme has a -d at the end, but -a and -d are opts to argv0 and will not work if they're presented after the cli.Command:

```
$ docker exec d4a35ea97944 hulk start --name smaaash --cmd "echo 2^128 | bc" -a /hulk.sock
Incorrect Usage.

NAME:
   hulk start - Start a job

USAGE:
   hulk start [command options] [arguments...]

OPTIONS:
   --name       Job name
   --artifacts  Where artifacts from a job are stored, relative to the temp dir where job is run
   --cmd, -c    Command to run
   --email      Email address to send job results
   
$ docker exec d4a35ea97944 hulk -a /hulk.sock start --name smaaash --cmd "echo 2^128 | bc" 
30328
```
